### PR TITLE
Put delete support

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -82,6 +82,8 @@
         <source-file src="src/android/com/synconset/CordovaHTTP/CordovaHttpGet.java" target-dir="src/com/synconset" />
         <source-file src="src/android/com/synconset/CordovaHTTP/CordovaHttpPost.java" target-dir="src/com/synconset" />
         <source-file src="src/android/com/synconset/CordovaHTTP/CordovaHttpPostJson.java" target-dir="src/com/synconset" />
+        <source-file src="src/android/com/synconset/CordovaHTTP/CordovaHttpPut.java" target-dir="src/com/synconset" />
+        <source-file src="src/android/com/synconset/CordovaHTTP/CordovaHttpDelete.java" target-dir="src/com/synconset" />
         <source-file src="src/android/com/synconset/CordovaHTTP/CordovaHttpUpload.java" target-dir="src/com/synconset" />
         <source-file src="src/android/com/synconset/CordovaHTTP/CordovaHttpDownload.java" target-dir="src/com/synconset" />
         <source-file src="src/android/com/synconset/CordovaHTTP/CordovaHttpPlugin.java" target-dir="src/com/synconset" />

--- a/src/android/com/synconset/CordovaHTTP/CordovaHttpDelete.java
+++ b/src/android/com/synconset/CordovaHTTP/CordovaHttpDelete.java
@@ -1,0 +1,63 @@
+/**
+ * A HTTP plugin for Cordova / Phonegap
+ */
+package com.synconset;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.UnknownHostException;
+import java.util.Map;
+
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.HostnameVerifier;
+
+import javax.net.ssl.SSLHandshakeException;
+
+import org.apache.cordova.CallbackContext;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import android.util.Log;
+
+import com.github.kevinsawicki.http.HttpRequest;
+import com.github.kevinsawicki.http.HttpRequest.HttpRequestException;
+ 
+public class CordovaHttpDelete extends CordovaHttp implements Runnable {
+    public CordovaHttpDelete(String urlString, Map<?, ?> params, Map<String, String> headers, CallbackContext callbackContext) {
+        super(urlString, params, headers, callbackContext);
+    }
+    
+    @Override
+    public void run() {
+        try {
+            HttpRequest request = HttpRequest.delete(this.getUrlString(), this.getParams(), true);
+            this.setupSecurity(request);
+            request.acceptCharset(CHARSET);
+            request.headers(this.getHeaders());
+            int code = request.code();
+            String body = request.body(CHARSET);
+            JSONObject response = new JSONObject();
+            response.put("status", code);
+            if (code >= 200 && code < 300) {
+                response.put("data", body);
+                this.getCallbackContext().success(response);
+            } else {
+                response.put("error", body);
+                this.getCallbackContext().error(response);
+            }
+        } catch (JSONException e) {
+            this.respondWithError("There was an error generating the response");
+        } catch (HttpRequestException e) {
+            if (e.getCause() instanceof UnknownHostException) {
+                this.respondWithError(0, "The host could not be resolved");
+            } else if (e.getCause() instanceof SSLHandshakeException) {
+                this.respondWithError("SSL handshake failed");
+            } else {
+                this.respondWithError("There was an error with the request");
+            }
+        }
+    }
+}

--- a/src/android/com/synconset/CordovaHTTP/CordovaHttpPlugin.java
+++ b/src/android/com/synconset/CordovaHTTP/CordovaHttpPlugin.java
@@ -73,7 +73,23 @@ public class CordovaHttpPlugin extends CordovaPlugin {
              HashMap<String, String> headersMap = this.addToMap(this.globalHeaders, headers);
              CordovaHttpPostJson postJson = new CordovaHttpPostJson(urlString, jsonObj, headersMap, callbackContext);
              cordova.getThreadPool().execute(postJson);
-         } else if (action.equals("useBasicAuth")) {
+        } else if (action.equals("put")) {
+            String urlString = args.getString(0);
+            JSONObject params = args.getJSONObject(1);
+            JSONObject headers = args.getJSONObject(2);
+            HashMap<?, ?> paramsMap = this.getMapFromJSONObject(params);
+            HashMap<String, String> headersMap = this.addToMap(this.globalHeaders, headers);
+            CordovaHttpPut put = new CordovaHttpPut(urlString, paramsMap, headersMap, callbackContext);
+            cordova.getThreadPool().execute(put);
+        } else if (action.equals("delete")) {
+            String urlString = args.getString(0);
+            JSONObject params = args.getJSONObject(1);
+            JSONObject headers = args.getJSONObject(2);
+            HashMap<?, ?> paramsMap = this.getMapFromJSONObject(params);
+            HashMap<String, String> headersMap = this.addToMap(this.globalHeaders, headers);
+            CordovaHttpDelete delete = new CordovaHttpDelete(urlString, paramsMap, headersMap, callbackContext);
+            cordova.getThreadPool().execute(delete);
+        } else if (action.equals("useBasicAuth")) {
             String username = args.getString(0);
             String password = args.getString(1);
             this.useBasicAuth(username, password);

--- a/src/android/com/synconset/CordovaHTTP/CordovaHttpPut.java
+++ b/src/android/com/synconset/CordovaHTTP/CordovaHttpPut.java
@@ -1,0 +1,56 @@
+/**
+ * A HTTP plugin for Cordova / Phonegap
+ */
+package com.synconset;
+
+import java.net.UnknownHostException;
+import java.util.Map;
+
+import org.apache.cordova.CallbackContext;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import javax.net.ssl.SSLHandshakeException;
+
+import android.util.Log;
+
+import com.github.kevinsawicki.http.HttpRequest;
+import com.github.kevinsawicki.http.HttpRequest.HttpRequestException;
+ 
+public class CordovaHttpPut extends CordovaHttp implements Runnable {
+    public CordovaHttpPut(String urlString, Map<?, ?> params, Map<String, String> headers, CallbackContext callbackContext) {
+        super(urlString, params, headers, callbackContext);
+    }
+    
+    @Override
+    public void run() {
+        try {
+            HttpRequest request = HttpRequest.put(this.getUrlString());
+            this.setupSecurity(request);
+            request.acceptCharset(CHARSET);
+            request.headers(this.getHeaders());
+            request.form(this.getParams());
+            int code = request.code();
+            String body = request.body(CHARSET);
+            JSONObject response = new JSONObject();
+            response.put("status", code);
+            if (code >= 200 && code < 300) {
+                response.put("data", body);
+                this.getCallbackContext().success(response);
+            } else {
+                response.put("error", body);
+                this.getCallbackContext().error(response);
+            }
+        } catch (JSONException e) {
+            this.respondWithError("There was an error generating the response");
+        }  catch (HttpRequestException e) {
+            if (e.getCause() instanceof UnknownHostException) {
+                this.respondWithError(0, "The host could not be resolved");
+            } else if (e.getCause() instanceof SSLHandshakeException) {
+                this.respondWithError("SSL handshake failed");
+            } else {
+                this.respondWithError("There was an error with the request");
+            }
+        }
+    }
+}

--- a/src/ios/CordovaHttpPlugin.h
+++ b/src/ios/CordovaHttpPlugin.h
@@ -11,6 +11,8 @@
 - (void)acceptAllCerts:(CDVInvokedUrlCommand*)command;
 - (void)post:(CDVInvokedUrlCommand*)command;
 - (void)get:(CDVInvokedUrlCommand*)command;
+- (void)put:(CDVInvokedUrlCommand*)command;
+- (void)delete:(CDVInvokedUrlCommand*)command;
 - (void)uploadFile:(CDVInvokedUrlCommand*)command;
 - (void)downloadFile:(CDVInvokedUrlCommand*)command;
 

--- a/src/ios/CordovaHttpPlugin.m
+++ b/src/ios/CordovaHttpPlugin.m
@@ -151,6 +151,55 @@
    }];
 }
 
+- (void)put:(CDVInvokedUrlCommand*)command {
+   HttpManager *manager = [HttpManager sharedClient];
+   NSString *url = [command.arguments objectAtIndex:0];
+   NSDictionary *parameters = [command.arguments objectAtIndex:1];
+   NSDictionary *headers = [command.arguments objectAtIndex:2];
+   [self setRequestHeaders: headers];
+   
+   CordovaHttpPlugin* __weak weakSelf = self;
+   manager.responseSerializer = [TextResponseSerializer serializer];
+   [manager PUT:url parameters:parameters success:^(AFHTTPRequestOperation *operation, id responseObject) {
+      NSMutableDictionary *dictionary = [NSMutableDictionary dictionary];
+      [dictionary setObject:[NSNumber numberWithInt:operation.response.statusCode] forKey:@"status"];
+      [dictionary setObject:responseObject forKey:@"data"];
+      CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:dictionary];
+      [weakSelf.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+   } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
+      NSMutableDictionary *dictionary = [NSMutableDictionary dictionary];
+      [dictionary setObject:[NSNumber numberWithInt:operation.response.statusCode] forKey:@"status"];
+      [dictionary setObject:[error localizedDescription] forKey:@"error"];
+      CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsDictionary:dictionary];
+      [weakSelf.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+   }];
+}
+
+- (void)delete:(CDVInvokedUrlCommand*)command {
+   HttpManager *manager = [HttpManager sharedClient];
+   NSString *url = [command.arguments objectAtIndex:0];
+   NSDictionary *parameters = [command.arguments objectAtIndex:1];
+   NSDictionary *headers = [command.arguments objectAtIndex:2];
+   [self setRequestHeaders: headers];
+   
+   CordovaHttpPlugin* __weak weakSelf = self;
+   
+   manager.responseSerializer = [TextResponseSerializer serializer];
+   [manager DELETE:url parameters:parameters success:^(AFHTTPRequestOperation *operation, id responseObject) {
+      NSMutableDictionary *dictionary = [NSMutableDictionary dictionary];
+      [dictionary setObject:[NSNumber numberWithInt:operation.response.statusCode] forKey:@"status"];
+      [dictionary setObject:responseObject forKey:@"data"];
+      CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:dictionary];
+      [weakSelf.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+   } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
+      NSMutableDictionary *dictionary = [NSMutableDictionary dictionary];
+      [dictionary setObject:[NSNumber numberWithInt:operation.response.statusCode] forKey:@"status"];
+      [dictionary setObject:[error localizedDescription] forKey:@"error"];
+      CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsDictionary:dictionary];
+      [weakSelf.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+   }];
+}
+
 - (void)uploadFile:(CDVInvokedUrlCommand*)command {
     HttpManager *manager = [HttpManager sharedClient];
     NSString *url = [command.arguments objectAtIndex:0];

--- a/www/cordovaHTTP.js
+++ b/www/cordovaHTTP.js
@@ -24,7 +24,13 @@ var http = {
     },
     postJson: function(url, json, headers, success, failure) {
          return exec(success, failure, "CordovaHttpPlugin", "postJson", [url, json, headers]);
-     },
+    },
+    put: function(url, params, headers, success, failure) {
+        return exec(success, failure, "CordovaHttpPlugin", "put", [url, params, headers]);
+    },
+    delete: function(url, params, headers, success, failure) {
+        return exec(success, failure, "CordovaHttpPlugin", "delete", [url, params, headers]);
+    },
     get: function(url, params, headers, success, failure) {
         return exec(success, failure, "CordovaHttpPlugin", "get", [url, params, headers]);
     },
@@ -119,6 +125,12 @@ if (typeof angular !== "undefined") {
             },
             postJson: function(url, json, headers) {
                  return makePromise(http.postJson, [url, json, headers], true);
+            },
+            put: function(url, params, headers) {
+                 return makePromise(http.put, [url, params, headers], true);
+            },
+            delete: function(url, params, headers) {
+                 return makePromise(http.delete, [url, params, headers], true);
             },
             get: function(url, params, headers) {
                 return makePromise(http.get, [url, params, headers], true);


### PR DESCRIPTION
Changes for adding support for PUT, DELETE methods in CordovaHttpPlugin for Ios and Android.

Note: I haven't succeeded in testing out this. I keep getting 'Invalid action' error message whenever I try to call either "delete" or "put" methods on the cordovaHttpPlugin object. I just tried android.

Please review:
@avikaza 
